### PR TITLE
Add grid as geojson layer to map

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -10,6 +10,7 @@
   <script src="../bower_components/angular-simple-logger/dist/angular-simple-logger.min.js"></script>
   <script src="../bower_components/ui-leaflet/dist/ui-leaflet.js"></script>
   <script src="../bower_components/ui-router/release/angular-ui-router.min.js"></script>
+  <script src="../bower_components/turf/turf.js"></script>
   
   <script src="js/app.js"></script>
   <script src="js/settings.js"></script>

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -1,8 +1,8 @@
 'use strict';
 
 mapApp.controller('MapCtrl',
-  ["$scope", "api", "defaults", "$stateParams", "leafletData",
-    function ($scope, api, defaults, $stateParams, leafletData) {
+  ["$scope", "api", "defaults", "$stateParams", "leafletData", "grid",
+    function ($scope, api, defaults, $stateParams, leafletData, grid) {
       var name = $stateParams.name;
 
       // set defaults for map positioning (as fallback)
@@ -49,6 +49,37 @@ mapApp.controller('MapCtrl',
           })
         });
       }
+
+      // Everytime you zoom or move the map, bounds will be changed.
+      // Therefor we watch bounds and regenerate the grid.
+      var gridLayer;
+      $scope.$watch("bounds", function() {
+        if($scope.bounds) {
+          var gridOverlay = grid.generateOverlay($scope.bounds);
+
+          // add grid as geoJson layer to map
+          // don't use ui-leaflet geoJSONShape because we need to set as
+          // background layer
+          leafletData.getMap().then(function(map) {
+            // remove old grid
+            if (gridLayer)
+              map.removeLayer(gridLayer);
+
+            gridLayer = L.geoJson(gridOverlay, {
+              style: {
+                weight: 2,
+                fillOpacity: 0,  // disable fill color
+                color: 'grey',
+              }
+            });
+
+            // add layer and set to background
+            map.addLayer(gridLayer);
+            gridLayer.bringToBack();
+          });
+        }
+      });
+
     }
   ]
 );

--- a/app/js/services.js
+++ b/app/js/services.js
@@ -1,9 +1,32 @@
 'use strict';
 
 mapApp
+  // Grid Service to generate grids for map
+  .service('grid', ['gridCells', 'leafletData',
+    function(gridCells, leafletData) {
+      var units = 'kilometers';
+
+      this.generateOverlay = function(bounds) {
+        var bottomLeft = [bounds.southWest.lng, bounds.southWest.lat];
+        var bottomRight = [bounds.northEast.lng, bounds.southWest.lat];
+        var topRight = [bounds.northEast.lng, bounds.northEast.lat];
+
+        // calculate distance for bottomLeft and bottomRight to be able to
+        // divide bbox into gridCells amount of cells
+        var dist = turf.distance(turf.point(bottomLeft), turf.point(bottomRight), units);
+        var cellWidth = dist/gridCells;
+
+        // grid for bbox of bottomLeft, topRight
+        var extent = bottomLeft.concat(topRight);
+        return turf.squareGrid(extent, cellWidth, units);
+      }
+    }
+  ])
+
+  // API service to interact with backend api
   .service('api', ['$http', 'domain', 'apiPrefix',
-    function($http, domain, apiPrefix){
-        var baseUrl = "//" + domain + apiPrefix;
+    function($http, domain, apiPrefix) {
+      var baseUrl = "//" + domain + apiPrefix;
 
         this.getMapList = function() {
             return $http.get(baseUrl);
@@ -17,6 +40,5 @@ mapApp
           var url = baseUrl + name + '/features';
           return $http.get(url);
         }
-      }
-    ]
-  );
+    }
+  ]);

--- a/app/js/settings.js
+++ b/app/js/settings.js
@@ -3,6 +3,7 @@
 mapApp
   .constant('domain', '//localhost:8080')
   .constant('apiPrefix', '/api/v1/maps/')
+  .constant('gridCells', 10)
   .constant('defaults', {
       lat: 51.505,   // London
       lng: -0.09,    // London

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
     "angular": "~1.4.7",
     "ui-leaflet": "~1.0.0",
     "ui-router": "~0.2.15",
-    "bootstrap": "~3.3.5"
+    "bootstrap": "~3.3.5",
+    "turf": "~2.0.0"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Use turf library to generate a square grid and add this geojson layer to
leaflet. Grid cell size are calculated dynamically (always gridCell amount of
cells on x-axis). The grid layer will always be the deepest layer (background).
This prevents malfunctionality of other layers.

Fixes #7.