### PR TITLE
Integrate testing with karma and jasmine

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
         "browser": true
     },
     "globals": {
-      "angular": false
+      "angular": false,
+      "turf": false
     },
     "plugins": [
         "html"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ before_script:
       - bower install
 script:
       - npm run lint
+      - npm run test
 sudo: false
 

--- a/app/js/services.js
+++ b/app/js/services.js
@@ -26,6 +26,10 @@ mapApp
 
       this.generateGridOverlay = function(bbox) {
         var bounds = boundsHelper.getBounds(bbox);
+        if (bounds.southWest.lng > bounds.northEast.lng ||
+            bounds.southWest.lat > bounds.northEast.lat)
+          throw new Error('ValueError');
+
         var bottomLeft = [bounds.southWest.lng, bounds.southWest.lat];
         var bottomRight = [bounds.northEast.lng, bounds.southWest.lat];
         var topRight = [bounds.northEast.lng, bounds.northEast.lat];

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
   "private": true,
   "dependencies": {
     "angular": "~1.4.7",
+    "angular-mocks": "*",
     "ui-leaflet": "~1.0.0",
     "leaflet-draw": "~0.2.4",
     "ui-router": "~0.2.15",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,78 @@
+// Karma configuration
+// Generated on Wed Dec 23 2015 12:50:42 GMT+0100 (CET)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'bower_components/angular/angular.js',
+      'bower_components/leaflet/dist/leaflet.js',
+      'bower_components/angular-simple-logger/dist/angular-simple-logger.min.js',
+      'bower_components/ui-leaflet/dist/ui-leaflet.js',
+      'bower_components/leaflet-draw/dist/leaflet.draw.js',
+      'bower_components/ui-router/release/angular-ui-router.min.js',
+      'bower_components/turf/turf.js',
+      'bower_components/angular-mocks/angular-mocks.js',
+      'app/**/*.js',
+      'test/*.js',
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultanous
+    concurrency: Infinity
+  })
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "lint": "eslint app/"
+    "lint": "eslint app/ test/",
+    "test": "karma start --single-run"
   },
   "repository": {
     "type": "git",
@@ -17,7 +18,11 @@
   "homepage": "https://github.com/KartographischeAktion/aktionskarten-frontend",
   "devDependencies": {
     "eslint": "*",
-    "eslint-plugin-html": "*"
+    "eslint-plugin-html": "*",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.13.15",
+    "karma-jasmine": "^0.3.6",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "phantomjs": "^1.9.19"
   }
 }
-

--- a/test/services.js
+++ b/test/services.js
@@ -1,0 +1,30 @@
+/* global describe, beforeEach, module, inject, it, expect */
+
+describe('generate an grid overlay with grid service', function() {
+  var grid;
+
+  beforeEach(module('mapApp'));
+  beforeEach(inject(function($injector) {
+    grid = $injector.get('grid');
+  }));
+
+  var southWest = [52.436339, 13.241272];
+  var northEast = [52.574681, 13.579102];
+  var bbox = southWest.concat(northEast);
+
+  it('grid generation should fail in case points are flipped', function() {
+    var bboxFlipped = northEast.concat(southWest);
+    expect(function() {
+      grid.generateGridOverlay(bboxFlipped);
+    }).toThrow(new Error('ValueError'));
+  });
+
+
+  it('southEast of bbox box should be inside of border overlay', function() {
+    var overlay = grid.generateBorderOverlay(bbox);
+    var tSouthWest = turf.point(southWest);
+
+    expect(turf.inside(tSouthWest, overlay)).toBeTruthy();
+  });
+
+});


### PR DESCRIPTION
We want to write unit tests to guarantee functionality. This changesets adds
basic functionality to write tests with jasmine and test them with karma.

Futhermore it adds an unit test for grid service.

You can trigger all tests in the following way
```
$ npm install   # only needed once
$ npm run test
```

See as well #12.