### PR TITLE
bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "private": true,
   "dependencies": {
     "angular": "~1.4.7",
-    "angular-mocks": "*",
+    "angular-mocks": "~1.4.7",
     "ui-leaflet": "~1.0.0",
     "leaflet-draw": "~0.2.4",
     "ui-router": "~0.2.15",


### PR DESCRIPTION
* prevent bower from asking for angular

A new install leads to bower not knowing which angular version to use.
Angular 1.5.0 (currently?) breaks the functionality.