### PR TITLE
Do not print controls

### DIFF
--- a/app/css/print.css
+++ b/app/css/print.css
@@ -12,7 +12,8 @@
     margin: 0;
 }
 
-.noprint {
+.noprint,
+.leaflet-control {
   display: none;
 }
 

--- a/app/index.html
+++ b/app/index.html
@@ -35,8 +35,8 @@
 
   <link rel="stylesheet" href="../bower_components/Leaflet.StyleEditor/dist/css/Leaflet.StyleEditor.min.css">
   <link rel="stylesheet" href="css/app.css" />
-  <link rel="stylesheet" href="css/print.css"  media="print" />
   <link rel="stylesheet" href="css/layer.css" />
+  <link rel="stylesheet" href="css/print.css"  media="print" />
 
 </head>
 <body>

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -77,7 +77,7 @@ mapApp.controller('MapCtrl',
           // generate Bbox layer
           borderLayer = L.rectangle(
             [[$scope.bounds.southWest.lat, $scope.bounds.southWest.lng],
-            [$scope.bounds.northEast.lat, $scope.bounds.northEast.lng]],
+              [$scope.bounds.northEast.lat, $scope.bounds.northEast.lng]],
             {
               className: 'border-layer'
             }
@@ -113,8 +113,8 @@ mapApp.controller('MapCtrl',
                 // check if feature is a circle
                 if (feature.properties && feature.properties.radius) {
                   layer = L.circle(layer.getLatLng(),
-                            feature.properties.radius,
-                            feature.properties
+                    feature.properties.radius,
+                    feature.properties
                   );
                 }
                 layer.id = feature.id;

--- a/app/js/services.js
+++ b/app/js/services.js
@@ -11,7 +11,7 @@ mapApp
       this.getBounds = function(bbox) {
         var bounds = leafletBoundsHelpers.createBoundsFromArray(
           [[bbox[3], bbox[2]],
-          [bbox[1], bbox[0]]]
+            [bbox[1], bbox[0]]]
         );
         if (bounds.southWest.lng > bounds.northEast.lng ||
             bounds.southWest.lat > bounds.northEast.lat)


### PR DESCRIPTION
* Prevent zoom to be printed to pdf.
* prevent leaflet.js accreditation being printed to pdf (it overlaps
with the bbox)